### PR TITLE
Upgrade otel v0.81.0

### DIFF
--- a/configs/1-1-localhost-windows-system.json
+++ b/configs/1-1-localhost-windows-system.json
@@ -68,7 +68,7 @@
               "hint": "Switch the toggle on if you want Logz.io Telemetry Collector to collect metrics from your computer.",
               "otel": {
                 "receivers": ["hostmetrics"],
-                "processors": ["resourcedetection_system", "attributes_agent"]
+                "processors": ["resourcedetection_system", "attributes_agent", "filter"]
 				      },
               "params": [],
               "dashboards": [

--- a/configs/1-2-localhost-linux-system.json
+++ b/configs/1-2-localhost-linux-system.json
@@ -45,7 +45,7 @@
               "hint": "Switch the toggle on if you want Logz.io Telemetry Collector to collect metrics from your computer.",
               "otel": {
                 "receivers": ["hostmetrics"],
-                "processors": ["resourcedetection_system", "attributes_agent"]
+                "processors": ["resourcedetection_system", "attributes_agent", "filter"]
 				      },
               "params": [],
               "dashboards": [

--- a/configs/1-3-localhost-mac-system.json
+++ b/configs/1-3-localhost-mac-system.json
@@ -45,7 +45,7 @@
               "hint": "Switch the toggle on if you want Logz.io Telemetry Collector to collect metrics from your computer.",
               "otel": {
                 "receivers": ["hostmetrics"],
-                "processors": ["resourcedetection_system", "attributes_agent"]
+                "processors": ["resourcedetection_system", "attributes_agent", "filter"]
 				      },
               "params": [],
               "dashboards": [

--- a/configs/3-1-aws-cw.json
+++ b/configs/3-1-aws-cw.json
@@ -12,7 +12,7 @@
        "description": "via Cloudwatch",
        "hint": "Cloudwatch logs to ship to Logz.io",
        "supportedOs": ["AWS_Cloudformation"],
-       "integrationTemplate": "firehose-logs/0.0.1/sam-template.yaml&param_logzioType=agent_logzio_firehose&param_logzioListener=https://aws-firehose-logs-<<LOGZIO_LISTENER_ADDRESS>>",
+       "integrationTemplate": "firehose-logs/0.0.1/sam-template.yaml&param_logzioType=agent-logzio-firehose&param_logzioListener=https://aws-firehose-logs-<<LOGZIO_LISTENER_ADDRESS>>",
        "datasources": [
          {
            "name": "AWS_Logs",

--- a/configs/3-3-aws-ec2-linux-system.json
+++ b/configs/3-3-aws-ec2-linux-system.json
@@ -44,7 +44,7 @@
                "hint": "Switch the toggle on if you want Logz.io Telemetry Collector to collect metrics from your EC2.",
                "otel": {
                 "receivers": ["hostmetrics"],
-                "processors": ["resourcedetection_system", "resourcedetection_ec2", "attributes_agent"]
+                "processors": ["resourcedetection_system", "resourcedetection_ec2", "attributes_agent", "filter"]
 				       },
                "params": [],
                "dashboards": [

--- a/resources-linux/otel/subtype_installer_utils.bash
+++ b/resources-linux/otel/subtype_installer_utils.bash
@@ -84,7 +84,7 @@ function download_otel_collector_binary {
     send_log_to_logzio "$LOG_LEVEL_DEBUG" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
     write_log "$LOG_LEVEL_DEBUG" "$message"
 
-    curl -fsSL "$OTEL_COLLECTOR_URL_DOWNLOAD" >"$LOGZIO_TEMP_DIR/otelcol-logzio.tar.gz" 2>"$TASK_ERROR_FILE"
+    curl -fsSL "$OTEL_COLLECTOR_URL_DOWNLOAD" >"$LOGZIO_TEMP_DIR/otelcol-contrib.tar.gz" 2>"$TASK_ERROR_FILE"
     if [[ $? -ne 0 ]]; then
         message="installer.bash ($EXIT_CODE): error downloading otelcol-logzio.tar.gz: $(get_task_error_message)"
         send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
@@ -93,9 +93,9 @@ function download_otel_collector_binary {
         return $EXIT_CODE
     fi
 
-    tar -zxf "$LOGZIO_TEMP_DIR/otelcol-logzio.tar.gz" --directory "$LOGZIO_TEMP_DIR" 2>"$TASK_ERROR_FILE"
+    tar -zxf "$LOGZIO_TEMP_DIR/otelcol-contrib.tar.gz" --directory "$LOGZIO_TEMP_DIR" 'otelcol-contrib' 2>"$TASK_ERROR_FILE"
     if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): error extracting files from otelcol-logzio.tar.gz: $(get_task_error_message)"
+        message="installer.bash ($EXIT_CODE): error extracting files from otelcol-contrib.tar.gz: $(get_task_error_message)"
         send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
         write_task_post_run "write_error \"$message\""
 

--- a/resources/otel/processors/attributes_agent.yaml
+++ b/resources/otel/processors/attributes_agent.yaml
@@ -1,5 +1,5 @@
 attributes/agent:
   actions:
     - key: logzio_agent_version
-      value: v1.0.36
+      value: v1.1.16
       action: insert

--- a/resources/otel/processors/filter.yaml
+++ b/resources/otel/processors/filter.yaml
@@ -1,0 +1,5 @@
+filter:
+  metrics:
+    include:
+      match_type: strict
+      metric_names: ["system.cpu.time", "system.cpu.load_average.1m", "system.cpu.load_average.5m", "system.cpu.load_average.15m", "system.cpu.utilization", "system.memory.usage", "system.filesystem.usage", "system.disk.io", "system.disk.io_time", "system.disk.operation_time", "system.network.connections", "system.network.io", "system.network.packets", "system.network.errors", "process.cpu.time", "process.memory.usage", "process.disk.io", "process.disk.io", "process.memory.usage", "process.memory.virtual"]

--- a/resources/otel/processors/filter.yaml
+++ b/resources/otel/processors/filter.yaml
@@ -2,4 +2,4 @@ filter:
   metrics:
     include:
       match_type: strict
-      metric_names: ["system.cpu.time", "system.cpu.load_average.1m", "system.cpu.load_average.5m", "system.cpu.load_average.15m", "system.cpu.utilization", "system.memory.usage", "system.filesystem.usage", "system.disk.io", "system.disk.io_time", "system.disk.operation_time", "system.network.connections", "system.network.io", "system.network.packets", "system.network.errors", "process.cpu.time", "process.memory.usage", "process.disk.io", "process.memory.usage", "process.memory.virtual"]
+      metric_names: ["system.cpu.time", "system.cpu.load_average.1m", "system.cpu.load_average.5m", "system.cpu.load_average.15m", "system.cpu.utilization", "system.memory.usage", "system.memory.utilization", "system.filesystem.usage", "system.disk.io", "system.disk.io_time", "system.disk.operation_time", "system.network.connections", "system.network.io", "system.network.packets", "system.network.errors", "process.cpu.time", "process.memory.usage", "process.disk.io", "process.memory.usage", "process.memory.virtual"]

--- a/resources/otel/processors/filter.yaml
+++ b/resources/otel/processors/filter.yaml
@@ -2,4 +2,4 @@ filter:
   metrics:
     include:
       match_type: strict
-      metric_names: ["system.cpu.time", "system.cpu.load_average.1m", "system.cpu.load_average.5m", "system.cpu.load_average.15m", "system.cpu.utilization", "system.memory.usage", "system.filesystem.usage", "system.disk.io", "system.disk.io_time", "system.disk.operation_time", "system.network.connections", "system.network.io", "system.network.packets", "system.network.errors", "process.cpu.time", "process.memory.usage", "process.disk.io", "process.disk.io", "process.memory.usage", "process.memory.virtual"]
+      metric_names: ["system.cpu.time", "system.cpu.load_average.1m", "system.cpu.load_average.5m", "system.cpu.load_average.15m", "system.cpu.utilization", "system.memory.usage", "system.filesystem.usage", "system.disk.io", "system.disk.io_time", "system.disk.operation_time", "system.network.connections", "system.network.io", "system.network.packets", "system.network.errors", "process.cpu.time", "process.memory.usage", "process.disk.io", "process.memory.usage", "process.memory.virtual"]

--- a/resources/otel/receivers/hostmetrics.yaml
+++ b/resources/otel/receivers/hostmetrics.yaml
@@ -1,7 +1,7 @@
 mac_run: |
   #!/bin/bash
   function create_otel_receiver {
-    $YQ_BIN -i 'del(.receiver.hostmetrics/NAME.scrapers.process)' "$OTEL_RECEIVERS_DIR/hostmetrics.yaml"
+    :
   }
 linux_run: |
   #!/bin/bash
@@ -19,6 +19,9 @@ receiver:
     collection_interval: 15s
     scrapers:
       cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
       disk:
       load:
       filesystem:
@@ -27,4 +30,5 @@ receiver:
       paging:
       process:
         mute_process_name_error: true
-
+        mute_process_exe_error: true
+        mute_process_io_error: true

--- a/resources/otel/receivers/hostmetrics.yaml
+++ b/resources/otel/receivers/hostmetrics.yaml
@@ -26,6 +26,9 @@ receiver:
       load:
       filesystem:
       memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
       network:
       paging:
       process:

--- a/scripts/linux/consts.bash
+++ b/scripts/linux/consts.bash
@@ -56,7 +56,7 @@ JQ_URL_DOWNLOAD='https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linu
 # Url for downloading yq binary
 YQ_URL_DOWNLOAD='https://github.com/mikefarah/yq/releases/download/v4.33.2/yq_linux_amd64.tar.gz'
 # Url for downloading OTEL collector tar.gz
-OTEL_COLLECTOR_URL_DOWNLOAD='https://github.com/logzio/otel-collector-distro/releases/download/v0.56.1/otelcol-logzio-linux_amd64.tar.gz'
+OTEL_COLLECTOR_URL_DOWNLOAD='https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.81.0/otelcol-contrib_0.81.0_linux_amd64.tar.gz'
 # Url for downloading eksctl tar.gz
 EKSCTL_URL_DOWNLOAD='https://github.com/weaveworks/eksctl/releases/download/v0.133.0/eksctl_Linux_amd64.tar.gz'
 # Url for AWS SQS
@@ -74,7 +74,7 @@ EKSCTL_BIN="$LOGZIO_TEMP_DIR/eksctl"
 # OTEL function file
 OTEL_FUNCTION_FILE="$LOGZIO_TEMP_DIR/otel_function.bash"
 # OTEL collector binary file name
-OTEL_COLLECTOR_BIN_NAME='otelcol-logzio-linux_amd64'
+OTEL_COLLECTOR_BIN_NAME='otelcol-contrib'
 # OTEL collector binary file path
 OTEL_COLLECTOR_BIN="$LOGZIO_OTEL_COLLECTOR_DIR/$OTEL_COLLECTOR_BIN_NAME"
 # OTEL config file name

--- a/scripts/mac/consts.bash
+++ b/scripts/mac/consts.bash
@@ -58,7 +58,7 @@ JQ_URL_DOWNLOAD='https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-
 # Url for downloading yq binary
 YQ_URL_DOWNLOAD='https://github.com/mikefarah/yq/releases/download/v4.33.2/yq_darwin_amd64.tar.gz'
 # Url for downloading OTEL collector tar.gz
-OTEL_COLLECTOR_URL_DOWNLOAD='https://github.com/logzio/otel-collector-distro/releases/download/v0.56.1/otelcol-logzio-darwin_amd64.tar.gz'
+OTEL_COLLECTOR_URL_DOWNLOAD='https://github.com/logzio/otel-collector-distro/releases/download/v0.81.0/otelcol-logzio-darwin_amd64.tar.gz'
 # Url for downloading eksctl tar.gz
 EKSCTL_URL_DOWNLOAD='https://github.com/weaveworks/eksctl/releases/download/v0.133.0/eksctl_Darwin_amd64.tar.gz'
 # Url for AWS SQS

--- a/scripts/windows/consts.ps1
+++ b/scripts/windows/consts.ps1
@@ -48,7 +48,7 @@ $script:JqUrlDownload = 'https://github.com/stedolan/jq/releases/download/jq-1.6
 # Url for downloading yq exe
 $script:YqUrlDownload = 'https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_windows_amd64.exe'
 # Url for downloading OTEL collector zip
-$script:OtelCollectorUrlDownload = 'https://github.com/logzio/otel-collector-distro/releases/download/v0.56.1/otelcol-logzio-windows_amd64.zip'
+$script:OtelCollectorUrlDownload = 'https://github.com/logzio/otel-collector-distro/releases/download/v0.81.0/otelcol-logzio-windows_amd64.zip'
 # Url for downloading eksctl zip
 $script:EksctlUrlDownload = 'https://github.com/weaveworks/eksctl/releases/download/v0.133.0/eksctl_Windows_amd64.zip'
 # Url for AWS SQS


### PR DESCRIPTION
Upgrade otel-contrib to v0.81.0:
- Linux takes the version directly from otel-contrib github.
- Mac and Windows take the version from our distro (mac -cgo is not enabled. windows - no zip in assets).

Filter processor was added to include only relevant metrics.