### PR TITLE
support old windows versions

### DIFF
--- a/scripts/windows/agent.ps1
+++ b/scripts/windows/agent.ps1
@@ -183,6 +183,7 @@ $WarningPreference = 'SilentlyContinue'
 [Console]::CursorVisible = $false
 
 # Agent status flags
+$script:IsInstallThreadJobModuleFailed = $false
 $script:IsShowHelp = $false
 $script:IsLoadingAgentScriptsFailed = $false
 $script:IsRemoveLastRunAnswerNo = $false

--- a/scripts/windows/functions.ps1
+++ b/scripts/windows/functions.ps1
@@ -25,9 +25,10 @@ function Install-ThreadJobModule {
             Write-Log $script:LogLevelDebug $Message
         }
         catch {
-            $script:IsLoadingAgentScriptsFailed = $true
-            Write-Error "agent.ps1 ($ExitCode): error installing 'ThreadJob' module: $_"
-            Exit $ExitCode
+            $script:IsInstallThreadJobModuleFailed = $true
+            $local:Message = "'ThreadJob' module was not installed successfully. Using regular jobs"
+            Send-LogToLogzio $script:LogLevelDebug $Message $script:LogStepPreInit $script:LogScriptAgent $FuncName $script:AgentId
+            Write-Log $script:LogLevelDebug $Message
         }
     }
 }


### PR DESCRIPTION
- Do not throw an error if was not installed successfully the ThreadJob module, and run Start-Job instead of Start-ThreadJob.
- Set TLS 1.2 