### PR TITLE
Change tags param to key-value type in Azure Fetcher config

### DIFF
--- a/configs/5-1-fetcher-azure.json
+++ b/configs/5-1-fetcher-azure.json
@@ -83,13 +83,13 @@
                   "noOptionsMessage": "Enter resource group name"
                 },
                 {
-                  "type": "text",
+                  "type": "key-value",
                   "name": "tags",
                   "label": "Tags",
                   "required": false,
                   "description": "",
                   "hint": "",
-                  "value": ""
+                  "value": []
                 },
                 {
                   "type": "multi-select",


### PR DESCRIPTION
Change param type to Key-Value
values are returned as
```
[
  { key: 'myKey', value: 'myVal }
]