### PR TITLE
 Logz.io Agent v1.1.25

### DIFF
--- a/datasources/linux/kubernetes/eks/kubernetes/installer/functions.bash
+++ b/datasources/linux/kubernetes/eks/kubernetes/installer/functions.bash
@@ -127,37 +127,11 @@ function get_is_fargate_was_selected {
 #   Eksctl binary file in Logz.io temp directory
 function download_eksctl {
     local func_name="${FUNCNAME[0]}"
+    local binary_name="eksctl"
+    local download_url=$(get_arch_specific_url "$EKSCTL_URL_DOWNLOAD" "$EKSCTL_ARM_URL_DOWNLOAD")
+    local binary_path="$LOGZIO_TEMP_DIR/$binary_name"
 
-    local message='Downloading eksctl ...'
-    send_log_to_logzio "$LOG_LEVEL_DEBUG" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
-    write_log "$LOG_LEVEL_DEBUG" "$message"
-
-    curl -fsSL "$EKSCTL_URL_DOWNLOAD" >"$LOGZIO_TEMP_DIR/eksctl.tar.gz" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
-
-    tar -zxf "$LOGZIO_TEMP_DIR/eksctl.tar.gz" --directory "$LOGZIO_TEMP_DIR" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): error extracting files from eksctl.tar.gz: $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
-
-    chmod +x "$EKSCTL_BIN" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): error giving execute premissions to '$EKSCTL_BIN': $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
+    download_binary "$download_url" "$binary_name" "$binary_path"
 }
 
 # Creates Fargate profile with monitoring namespace on Kubernetes cluster

--- a/datasources/mac/kubernetes/eks/kubernetes/installer/functions.bash
+++ b/datasources/mac/kubernetes/eks/kubernetes/installer/functions.bash
@@ -127,38 +127,13 @@ function get_is_fargate_was_selected {
 #   Eksctl binary file in Logz.io temp directory
 function download_eksctl {
     local func_name="${FUNCNAME[0]}"
+    local binary_name="eksctl"
+    local download_url=$(get_arch_specific_url "$EKSCTL_URL_DOWNLOAD" "$EKSCTL_ARM_URL_DOWNLOAD")
+    local binary_path="$LOGZIO_TEMP_DIR/$binary_name"
 
-    local message='Downloading eksctl ...'
-    send_log_to_logzio "$LOG_LEVEL_DEBUG" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
-    write_log "$LOG_LEVEL_DEBUG" "$message"
-
-    curl -fsSL "$EKSCTL_URL_DOWNLOAD" >"$LOGZIO_TEMP_DIR/eksctl.tar.gz" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
-
-    tar -zxf "$LOGZIO_TEMP_DIR/eksctl.tar.gz" --directory "$LOGZIO_TEMP_DIR" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): error extracting files from eksctl.tar.gz: $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
-
-    chmod +x "$EKSCTL_BIN" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): error giving execute premissions to '$EKSCTL_BIN': $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
+    download_binary "$download_url" "$binary_name" "$binary_path"
 }
+
 
 # Creates Fargate profile with monitoring namespace on Kubernetes cluster
 # Input:

--- a/resources-linux/otel/subtype_installer_utils.bash
+++ b/resources-linux/otel/subtype_installer_utils.bash
@@ -79,39 +79,11 @@ function remove_logzio_otel_collector_service {
 #   OTEL collector exe in Logz.io temp directory
 function download_otel_collector_binary {
     local func_name="${FUNCNAME[0]}"
+    local binary_name="$OTEL_COLLECTOR_BIN_NAME"
+    local download_url=$(get_arch_specific_url "$OTEL_COLLECTOR_URL_DOWNLOAD" "$OTEL_COLLECTOR_ARM_URL_DOWNLOAD")
+    local binary_path="$LOGZIO_TEMP_DIR/$binary_name"
 
-    local message='Downloading OTEL collector binary ...'
-    send_log_to_logzio "$LOG_LEVEL_DEBUG" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
-    write_log "$LOG_LEVEL_DEBUG" "$message"
-
-    if [[ ! -z "$PROXY" ]]; then
-        curl --proxy "$PROXY" -fsSL "$OTEL_COLLECTOR_URL_DOWNLOAD" >"$LOGZIO_TEMP_DIR/otelcol-contrib.tar.gz" 2>"$TASK_ERROR_FILE"
-        if [[ $? -ne 0 ]]; then
-            message="installer.bash ($EXIT_CODE): error downloading otelcol-logzio.tar.gz: $(get_task_error_message)"
-            send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
-            write_task_post_run "write_error \"$message\""
-
-            return $EXIT_CODE
-        fi
-    else
-        curl -fsSL "$OTEL_COLLECTOR_URL_DOWNLOAD" >"$LOGZIO_TEMP_DIR/otelcol-contrib.tar.gz" 2>"$TASK_ERROR_FILE"
-        if [[ $? -ne 0 ]]; then
-            message="installer.bash ($EXIT_CODE): error downloading otelcol-logzio.tar.gz: $(get_task_error_message)"
-            send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
-            write_task_post_run "write_error \"$message\""
-
-            return $EXIT_CODE
-        fi
-    fi
-
-    tar -zxf "$LOGZIO_TEMP_DIR/otelcol-contrib.tar.gz" --directory "$LOGZIO_TEMP_DIR" 'otelcol-contrib' 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): error extracting files from otelcol-contrib.tar.gz: $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
+    download_binary "$download_url" "$binary_name" "$binary_path"
 }
 
 # Creates Logz.io opt subdirectory

--- a/resources-mac/otel/subtype_installer_utils.bash
+++ b/resources-mac/otel/subtype_installer_utils.bash
@@ -71,28 +71,11 @@ function remove_logzio_otel_collector_service {
 #   OTEL collector exe in Logz.io temp directory
 function download_otel_collector_binary {
     local func_name="${FUNCNAME[0]}"
+    local binary_name="$OTEL_COLLECTOR_BIN_NAME"
+    local download_url=$(get_arch_specific_url "$OTEL_COLLECTOR_URL_DOWNLOAD" "$OTEL_COLLECTOR_ARM_URL_DOWNLOAD")
+    local binary_path="$LOGZIO_TEMP_DIR/$binary_name"
 
-    local message='Downloading OTEL collector binary ...'
-    send_log_to_logzio "$LOG_LEVEL_DEBUG" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
-    write_log "$LOG_LEVEL_DEBUG" "$message"
-
-    curl -fsSL "$OTEL_COLLECTOR_URL_DOWNLOAD" >"$LOGZIO_TEMP_DIR/otelcol-logzio.tar.gz" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): error downloading otelcol-logzio.tar.gz: $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
-
-    tar -zxf "$LOGZIO_TEMP_DIR/otelcol-logzio.tar.gz" --directory "$LOGZIO_TEMP_DIR" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="installer.bash ($EXIT_CODE): error extracting files from otelcol-logzio.tar.gz: $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_PRE_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
+    download_binary "$download_url" "$binary_name" "$binary_path"
 }
 
 # Creates Logz.io opt subdirectory

--- a/resources/otel/receivers/hostmetrics.yaml
+++ b/resources/otel/receivers/hostmetrics.yaml
@@ -32,6 +32,9 @@ receiver:
       network:
       paging:
       process:
+        exclude:
+          names: ['launcher']
+          match_type: strict 
         mute_process_name_error: true
         mute_process_exe_error: true
         mute_process_io_error: true

--- a/scripts/linux/consts.bash
+++ b/scripts/linux/consts.bash
@@ -53,13 +53,21 @@ AGENT_JSON="$LOGZIO_TEMP_DIR/agent.json"
 
 ## Urls
 # Url for downloading jq binary
-JQ_URL_DOWNLOAD='https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64'
+JQ_URL_DOWNLOAD='https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux64'
 # Url for downloading yq binary
-YQ_URL_DOWNLOAD='https://github.com/mikefarah/yq/releases/download/v4.33.2/yq_linux_amd64.tar.gz'
+YQ_URL_DOWNLOAD='https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64.tar.gz'
 # Url for downloading OTEL collector tar.gz
 OTEL_COLLECTOR_URL_DOWNLOAD='https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.82.0/otelcol-contrib_0.82.0_linux_amd64.tar.gz'
 # Url for downloading eksctl tar.gz
 EKSCTL_URL_DOWNLOAD='https://github.com/weaveworks/eksctl/releases/download/v0.133.0/eksctl_Linux_amd64.tar.gz'
+# Url for downloading jq arm64 binary
+JQ_ARM_URL_DOWNLOAD='https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux-arm64'
+# Url for downloading yq arm64 binary
+YQ_ARM_URL_DOWNLOAD='https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_arm64.tar.gz'
+# Url for downloading OTEL collector arm64 tar.gz
+OTEL_COLLECTOR_ARM_URL_DOWNLOAD='https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.82.0/otelcol-contrib_0.82.0_linux_arm64.tar.gz'
+# Url for downloading eksctl arm64 tar.gz
+EKSCTL_ARM_URL_DOWNLOAD='https://github.com/weaveworks/eksctl/releases/download/v0.133.0/eksctl_linux_arm64.tar.gz'
 # Url for AWS SQS
 SQS_URL='https://sqs.us-east-1.amazonaws.com/486140753397/LogzioAgentQueue'
 
@@ -67,7 +75,7 @@ SQS_URL='https://sqs.us-east-1.amazonaws.com/486140753397/LogzioAgentQueue'
 # Jq binary file path
 JQ_BIN="$LOGZIO_TEMP_DIR/jq"
 # Yq binary file path
-YQ_BIN="$LOGZIO_TEMP_DIR/yq_linux_amd64"
+YQ_BIN="$LOGZIO_TEMP_DIR/yq"
 # Eksctl binary file path
 EKSCTL_BIN="$LOGZIO_TEMP_DIR/eksctl"
 

--- a/scripts/linux/utils_functions.bash
+++ b/scripts/linux/utils_functions.bash
@@ -61,8 +61,9 @@ function write_task_post_run {
 function get_task_error_message {
     local err=$(cat "$TASK_ERROR_FILE")
     err="${err//\"/\\\"}"
-
-    echo -e "$err"
+    if [[ -n "$err" ]]; then
+        echo -e "$err"
+    fi    
 }
 
 # Sends log to Logz.io
@@ -583,4 +584,51 @@ function execute_task {
 
     ((EXIT_CODE++))
     >"$TASK_POST_RUN_FILE"
+}
+
+# Check if binary is already installed with the correct version
+function copy_installed_binary {
+    local binary_name="$1"
+    local download_url="$2"
+    local binary_path="$3"
+
+    # Check if the binary is installed
+    if command -v "$binary_name" &>/dev/null; then
+        # If version validation is not required, binary is considered installed
+        if [ -z "$download_url" ]; then
+            # Copy the installed binary to the specified path, if provided
+            if [ -n "$binary_path" ]; then
+                cp "$(command -v "$binary_name")" "$binary_path"
+            fi
+            return 0  # Binary is installed
+        fi
+
+        # Fetch the content of the version URL
+        downloaded_version=$(curl -s "$download_url")
+
+        # Check if the downloaded version matches the installed version
+        installed_version=$("$binary_name" --version | head -n 1)
+        if echo "$installed_version" | grep -E -q "$downloaded_version"; then
+            # Copy the installed binary to the specified path, if provided
+            if [ -n "$binary_path" ]; then
+                cp "$(command -v "$binary_name")" "$binary_path"
+            fi
+            return 0  # Binary is installed with the correct version
+        else
+            return 1  # Binary is installed, but version does not match
+        fi
+    else
+        return 1  # Binary is not installed
+    fi
+}
+# Function to get the architecture-specific download URL
+function get_arch_specific_url {
+    local default_url="$1"
+    local arm_url="$2"
+
+    if [[ ( "$CPU_ARCH" == "arm64" || "$CPU_ARCH" == "aarch64" ) && ! -z "$arm_url" ]]; then
+        echo "$arm_url"
+    else
+        echo "$default_url"
+    fi
 }

--- a/scripts/mac/consts.bash
+++ b/scripts/mac/consts.bash
@@ -55,13 +55,21 @@ AGENT_JSON="$LOGZIO_TEMP_DIR/agent.json"
 
 ## Urls
 # Url for downloading jq binary
-JQ_URL_DOWNLOAD='https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64'
+JQ_URL_DOWNLOAD='https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-osx-amd64'
 # Url for downloading yq binary
-YQ_URL_DOWNLOAD='https://github.com/mikefarah/yq/releases/download/v4.33.2/yq_darwin_amd64.tar.gz'
+YQ_URL_DOWNLOAD='https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_darwin_amd64.tar.gz'
 # Url for downloading OTEL collector tar.gz
 OTEL_COLLECTOR_URL_DOWNLOAD='https://github.com/logzio/otel-collector-distro/releases/download/v0.82.0/otelcol-logzio-darwin_amd64.tar.gz'
 # Url for downloading eksctl tar.gz
 EKSCTL_URL_DOWNLOAD='https://github.com/weaveworks/eksctl/releases/download/v0.133.0/eksctl_Darwin_amd64.tar.gz'
+# Url for downloading jq arm64 binary
+JQ_ARM_URL_DOWNLOAD='https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-macos-arm64'
+# Url for downloading yq arm64 binary
+YQ_ARM_URL_DOWNLOAD='https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_darwin_arm64.tar.gz'
+# Url for downloading OTEL collector arm64 tar.gz
+OTEL_COLLECTOR_ARM_URL_DOWNLOAD='https://github.com/logzio/otel-collector-distro/releases/download/v0.82.0/otelcol-logzio-darwin_arm64.tar.gz'
+# Url for downloading eksctl arm64 tar.gz
+EKSCTL_ARM_URL_DOWNLOAD='https://github.com/weaveworks/eksctl/releases/download/v0.133.0/eksctl_Darwin_arm64.tar.gz'
 # Url for AWS SQS
 SQS_URL='https://sqs.us-east-1.amazonaws.com/486140753397/LogzioAgentQueue'
 
@@ -69,7 +77,7 @@ SQS_URL='https://sqs.us-east-1.amazonaws.com/486140753397/LogzioAgentQueue'
 # Jq binary file path
 JQ_BIN="$LOGZIO_TEMP_DIR/jq"
 # Yq binary file path
-YQ_BIN="$LOGZIO_TEMP_DIR/yq_darwin_amd64"
+YQ_BIN="$LOGZIO_TEMP_DIR/yq"
 # Eksctl binary file path
 EKSCTL_BIN="$LOGZIO_TEMP_DIR/eksctl"
 
@@ -77,7 +85,7 @@ EKSCTL_BIN="$LOGZIO_TEMP_DIR/eksctl"
 # OTEL function file
 OTEL_FUNCTION_FILE="$LOGZIO_TEMP_DIR/otel_function.bash"
 # OTEL collector binary file name
-OTEL_COLLECTOR_BIN_NAME='otelcol-logzio-darwin_amd64'
+OTEL_COLLECTOR_BIN_NAME='otelcol-logzio'
 # OTEL collector binary file path
 OTEL_COLLECTOR_BIN="$LOGZIO_OTEL_COLLECTOR_DIR/$OTEL_COLLECTOR_BIN_NAME"
 # OTEL config file name

--- a/scripts/mac/functions.bash
+++ b/scripts/mac/functions.bash
@@ -31,7 +31,7 @@ function get_mac_info {
     write_task_post_run "MAC_NAME=\"$mac_name\""
 
     message="Mac name is '$mac_name'"
-    send_log_to_logzio "$LOG_LEVEL_DEBUG" "$message" "$LOG_STEP_PRE_INIT" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
+    send_log_to_logzio "$LOG_LEVEL_DEBUG"˜ "$message" "$LOG_STEP_PRE_INIT" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
     write_log "$LOG_LEVEL_DEBUG" "$message"
 
     local mac_version=$(echo -e "$mac_info" | grep 'ProductVersion:' | tr -d " \t\n\r" | cut -d':' -f2)
@@ -242,6 +242,139 @@ function check_arguments_validation {
     return $EXIT_CODE
 }
 
+# Download binary
+function download_binary {
+    local download_url="$1"
+    local binary_name="$2"
+    local binary_path="$3"
+    local func_name="${FUNCNAME[0]}"
+
+    # Check if the binary is already installed
+    if copy_installed_binary "$binary_name" "$download_url" "$binary_path"; then
+        write_log "$LOG_LEVEL_DEBUG" "$binary_name is already installed. Skipping download."
+        return 0
+    fi
+
+    # Download the binary
+    local downloaded_file
+    if [[ "$download_url" == *".tar.gz" ]]; then
+        downloaded_file=$(download_tarball "$download_url" "$binary_name")
+    else
+        downloaded_file=$(download_direct "$download_url" "$binary_path") || return 1
+    fi
+
+    # Provide execution permissions to binary file
+    chmod_binary "$binary_path" "$func_name" || return 1
+
+    return 0
+}
+
+# Helper function to download tarballs
+function download_tarball {
+    local download_url="$1"
+    local binary_name="$2"
+    local tar_path="$LOGZIO_TEMP_DIR/$binary_name.tar.gz"
+
+    # Create a timestamp-based subdirectory for extraction
+    local extract_dir="$LOGZIO_TEMP_DIR/${binary_name}_extract"
+    mkdir -p "$extract_dir"
+
+    # Download the tarball
+    curl -fsSL "$download_url" >"$tar_path" 2>"$TASK_ERROR_FILE"
+    if [[ $? -ne 0 ]]; then
+        message="installer.bash: error downloading $binary_name.tar.gz: $(get_task_error_message)"
+        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "${FUNCNAME[1]}" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
+        write_task_post_run "write_error \"$message\""
+        return 1
+    fi
+
+    # Extract the tarball
+    tar -zxf "$tar_path" --directory "$extract_dir" 2>"$TASK_ERROR_FILE"
+    if [[ $? -ne 0 ]]; then
+        message="installer.bash: error extracting files from $tar_path: $(get_task_error_message)"
+        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "${FUNCNAME[1]}" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
+        write_task_post_run "write_error \"$message\""
+        return 1
+    fi
+
+    # Find the extracted binary
+    local extracted_binary
+    extracted_binary=$(find "$extract_dir" -maxdepth 1 -type f -name "${binary_name}*" ! -name "*.*" | head -n 1)
+
+    if [[ -z "$extracted_binary" ]]; then
+        message="installer.bash: no matching binary file named: ${binary_name} found in the extracted directory"
+        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "${FUNCNAME[1]}" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
+        write_task_post_run "write_error \"$message\""
+        return 1
+    fi
+
+    # Move the binary to the destination
+    move_binary "$extracted_binary" "$LOGZIO_TEMP_DIR/$binary_name"
+
+    # Clean up the temporary directory and tar file
+    rm -rf "$extract_dir" "$LOGZIO_TEMP_DIR/$binary_name.tar.gz"
+
+    echo "$binary_name"
+}
+
+
+# Helper function to download binary directly
+function download_direct {
+    local download_url="$1"
+    local binary_path="$2"
+
+    curl -fsSL --create-dirs "$download_url" >"$binary_path" 2>"$TASK_ERROR_FILE"
+    if [[ $? -ne 0 ]]; then
+        message="installer.bash: error downloading binary: $(get_task_error_message)"
+        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
+        write_task_post_run "write_error \"$message\""
+        return 1
+    fi
+
+    echo "$binary_path"
+}
+
+# Helper function to move the binary to the destination
+function move_binary {
+    local source_path="$1"
+    local binary_path="$2"
+    local func_name="$3"
+
+    if [[ -z "$source_path" ]]; then
+        message="installer.bash: error moving binary to $binary_path: Source path is empty"
+        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
+        write_task_post_run "write_error \"$message\""
+        return 1
+    fi
+
+    mv "$source_path" "$binary_path"
+    if [[ $? -ne 0 ]]; then
+        message="installer.bash: error moving binary to $binary_path: $(get_task_error_message)"
+        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
+        write_task_post_run "write_error \"$message\""
+        return 1
+    fi
+
+    return 0
+}
+
+# Helper function to provide execution permissions to binary file
+function chmod_binary {
+    local binary_path="$1"
+    local func_name="$2"
+
+    chmod +x "$binary_path" 2>"$TASK_ERROR_FILE"
+    if [[ $? -ne 0 ]]; then
+        message="installer.bash: error giving execute permissions to '$binary_path': $(get_task_error_message)"
+        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_INSTALLATION" "$LOG_SCRIPT_INSTALLER" "$func_name" "$AGENT_ID" "$PLATFORM" "$SUB_TYPE" "$CURRENT_DATA_SOURCE"
+        write_task_post_run "write_error \"$message\""
+        return 1
+    fi
+
+    return 0
+}
+
+
 # Downloads jq
 # Input:
 #   ---
@@ -249,28 +382,11 @@ function check_arguments_validation {
 #   Jq binary file in Logz.io temp directory
 function download_jq {
     local func_name="${FUNCNAME[0]}"
-
-    local message='Downloading jq ...'
-    send_log_to_logzio "$LOG_LEVEL_DEBUG" "$message" "$LOG_STEP_DOWNLOADS" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
-    write_log "$LOG_LEVEL_DEBUG" "$message"
-
-    curl -fsSL "$JQ_URL_DOWNLOAD" >"$JQ_BIN" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="agent.bash ($EXIT_CODE): error downloading jq binary: $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_DOWNLOADS" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
-
-    chmod +x "$JQ_BIN" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="agent.bash ($EXIT_CODE): error giving execute premissions to '$JQ_BIN': $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_DOWNLOADS" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
+    local binary_name="jq"
+    local binary_path="$LOGZIO_TEMP_DIR/$binary_name"
+    local download_url=$(get_arch_specific_url "$JQ_URL_DOWNLOAD" "$JQ_ARM_URL_DOWNLOAD")
+    
+    download_binary "$download_url" "$binary_name" "$binary_path"
 }
 
 # Downloads yq
@@ -280,37 +396,11 @@ function download_jq {
 #   Yq binary file in Logz.io temp directory
 function download_yq {
     local func_name="${FUNCNAME[0]}"
-
-    local message='Downloading yq ...'
-    send_log_to_logzio "$LOG_LEVEL_DEBUG" "$message" "$LOG_STEP_DOWNLOADS" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
-    write_log "$LOG_LEVEL_DEBUG" "$message"
-
-    curl -fsSL "$YQ_URL_DOWNLOAD" >"$LOGZIO_TEMP_DIR/yq.tar.gz" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="agent.bash ($EXIT_CODE): error downloading yq tar.gz: $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_DOWNLOADS" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
-
-    tar -zxf "$LOGZIO_TEMP_DIR/yq.tar.gz" --directory "$LOGZIO_TEMP_DIR" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="agent.bash ($EXIT_CODE): error extracting yq tar.gz file: $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_DOWNLOADS" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
-
-    chmod +x "$YQ_BIN" 2>"$TASK_ERROR_FILE"
-    if [[ $? -ne 0 ]]; then
-        message="agent.bash ($EXIT_CODE): error giving execute premissions to '$YQ_BIN': $(get_task_error_message)"
-        send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_DOWNLOADS" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
-        write_task_post_run "write_error \"$message\""
-
-        return $EXIT_CODE
-    fi
+    local binary_name="yq"
+    local binary_path="$LOGZIO_TEMP_DIR/$binary_name"
+    local download_url=$(get_arch_specific_url "$YQ_URL_DOWNLOAD" "$YQ_ARM_URL_DOWNLOAD")
+    
+    download_binary "$download_url" "$binary_name" "$binary_path"
 }
 
 # Gets the agent json from the agent or local file

--- a/scripts/mac/utils_functions.bash
+++ b/scripts/mac/utils_functions.bash
@@ -580,3 +580,50 @@ function execute_task {
     ((EXIT_CODE++))
     >"$TASK_POST_RUN_FILE"
 }
+
+# Check if binary is already installed with the correct version, if it does copy it
+function copy_installed_binary {
+    local binary_name="$1"
+    local download_url="$2"
+    local binary_path="$3"
+
+    # Check if the binary is installed
+    if command -v "$binary_name" &>/dev/null; then
+        # If version validation is not required, binary is considered installed
+        if [ -z "$download_url" ]; then
+            # Copy the installed binary to the specified path, if provided
+            if [ -n "$binary_path" ]; then
+                cp "$(command -v "$binary_name")" "$binary_path"
+            fi
+            return 0  # Binary is installed
+        fi
+
+        # Fetch the content of the version URL
+        downloaded_version=$(curl -s "$download_url")
+
+        # Check if the downloaded version matches the installed version
+        installed_version=$("$binary_name" --version | head -n 1)
+        if echo "$installed_version" | grep -E -q "$downloaded_version"; then
+            # Copy the installed binary to the specified path, if provided
+            if [ -n "$binary_path" ]; then
+                cp "$(command -v "$binary_name")" "$binary_path"
+            fi
+            return 0  # Binary is installed with the correct version
+        else
+            return 1  # Binary is installed, but version does not match
+        fi
+    else
+        return 1  # Binary is not installed
+    fi
+}
+# Function to get the architecture-specific download URL
+function get_arch_specific_url {
+    local default_url="$1"
+    local arm_url="$2"
+
+    if [[ ( "$CPU_ARCH" == "arm64" || "$CPU_ARCH" == "aarch64" ) && ! -z "$arm_url" ]]; then
+        echo "$arm_url"
+    else
+        echo "$default_url"
+    fi
+}


### PR DESCRIPTION
- Added ARM64 support for linux and macOs
  - yq, jq , otel, eksctl
- Upgraded jqbinary to v1.7.1
- Upgraded yqbinary to v4.40.5
- Added exclusion of launcher process metrics as temp solution due to errors (hostmetrics.yaml) - error reading command for process \"launcher\ - error reading memory info for process \"launcher\" (pid 765): no such process; error reading cpu times for process
- Created a common function for downloading binaries
  - Helper functions for binary permissions, moving binary, direct download, tar.gz files download support & detect cpu arch to use correct download url.
  - Created a common function to check if a binary with same version exists before download - if it does then copy it to binary path.