### PR TITLE
uname -p is not portable

### DIFF
--- a/scripts/linux/functions.bash
+++ b/scripts/linux/functions.bash
@@ -41,7 +41,7 @@ function get_linux_info {
     send_log_to_logzio "$LOG_LEVEL_DEBUG" "$message" "$LOG_STEP_PRE_INIT" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"
     write_log "$LOG_LEVEL_DEBUG" "$message"
 
-    local cpu_arch=$(uname -p 2>"$TASK_ERROR_FILE")
+    local cpu_arch=$(uname -m 2>"$TASK_ERROR_FILE")
     if [[ $? -ne 0 ]]; then
         message="agent.bash ($EXIT_CODE): error getting cpu arch: $(get_task_error_message)"
         send_log_to_logzio "$LOG_LEVEL_ERROR" "$message" "$LOG_STEP_PRE_INIT" "$LOG_SCRIPT_AGENT" "$func_name" "$AGENT_ID"


### PR DESCRIPTION
`uname -p` (and -i) are not portable.  From the POSIX standpoint these commands will return "unknown" unless the operating system explicity patches for them.

For example, Debian does not return an appropriate value for uname -p.

```
~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 11 (bullseye)
Release:	11
Codename:	bullseye
~$ uname -i
unknown
~$ uname -p
unknown
~$ uname -m
x86_64

`uname -m` should be used for cross compatability.