### PR TITLE
Add type globally & Fix log file path & name attributes location

### DIFF
--- a/resources/otel/processors/resource_agent.yaml
+++ b/resources/otel/processors/resource_agent.yaml
@@ -1,5 +1,8 @@
 resource/agent:
   attributes:
     - key: logzio_agent_version
-      value: v1.1.21
+      value: v1.1.32
       action: upsert
+    - key: type
+      value: agent-windows
+      action: upsert      

--- a/resources/otel/receivers/filelog.yaml
+++ b/resources/otel/receivers/filelog.yaml
@@ -73,9 +73,7 @@ receiver:
     operators:
       - type: move
         from: attributes["log.file.name"]
-        to: attributes["log_file_name"]
+        to: resource["log_file_name"]
       - type: move
         from: attributes["log.file.path"]
-        to: attributes["log_file_path"]
-    resource:
-      type:
+        to: resource["log_file_path"]

--- a/resources/otel/receivers/windowseventlog_application.yaml
+++ b/resources/otel/receivers/windowseventlog_application.yaml
@@ -36,5 +36,3 @@ receiver:
   windowseventlog/application/NAME:
     channel: Application
     exclude_providers: []
-    resource:
-      type:

--- a/resources/otel/receivers/windowseventlog_security.yaml
+++ b/resources/otel/receivers/windowseventlog_security.yaml
@@ -29,5 +29,3 @@ windows_run: |
 receiver:
   windowseventlog/security/NAME:
     channel: Security
-    resource:
-      type:

--- a/resources/otel/receivers/windowseventlog_system.yaml
+++ b/resources/otel/receivers/windowseventlog_system.yaml
@@ -29,5 +29,3 @@ windows_run: |
 receiver:
   windowseventlog/system/NAME:
     channel: System
-    resource:
-      type:


### PR DESCRIPTION
- The log type: `agent-windows` will be added to all logs and not per receiver
- Bug where the log file attributes weren't sent in the resource log was fixed.