### PR TITLE
Re-add `cloudwatch-shipper-trigger` shipping method

### DIFF
--- a/configs/3-1-aws-cw.json
+++ b/configs/3-1-aws-cw.json
@@ -113,6 +113,201 @@
            ]
          }
        ]
-     }
+     },
+     {
+      "name": "AWS_Cloudwatch_Logs",
+      "logo": "https://dytvr9ot2sszz.cloudfront.net/logz-docs/shipper-logos/aws.svg",
+      "label": "AWS Cloudwatch Logs",
+      "description": "via Cloudwatch using AWS Lambda",
+      "hint": "Cloudwatch logs to ship to Logz.io",
+      "supportedOs": [
+        "AWS_Cloudformation"
+      ],
+      "integrationTemplate": "cloudwatch-shipper-trigger/1.1.1/sam-template.yaml&param_logzioType=agent-aws-cloudwatch&param_logzioListener=https://<<LOGZIO_LISTENER_ADDRESS>>:8071",
+      "datasources": [
+        {
+          "name": "AWS_Cloudwatch_Logs",
+          "logo": "https://dytvr9ot2sszz.cloudfront.net/logz-docs/shipper-logos/aws-cloudwatch.png",
+          "label": "AWS Cloudwatch Logs",
+          "description": "Ship your Cloudwatch logs to Logz.io",
+          "params": [
+            {
+              "type": "single-select",
+              "name": "awsRegion",
+              "label": "AWS Region",
+              "description": "AWS Region",
+              "required": true,
+              "hint": "Your AWS account region",
+              "options": [
+                {
+                  "label": "us-east-1",
+                  "value": "us-east-1"
+                },
+                {
+                  "label": "us-east-2",
+                  "value": "us-east-2"
+                },
+                {
+                  "label": "us-west-1",
+                  "value": "us-west-1"
+                },
+                {
+                  "label": "us-west-2",
+                  "value": "us-west-2"
+                },
+                {
+                  "label": "eu-central-1",
+                  "value": "eu-central-1"
+                },
+                {
+                  "label": "eu-north-1",
+                  "value": "eu-north-1"
+                },
+                {
+                  "label": "eu-west-1",
+                  "value": "eu-west-1"
+                },
+                {
+                  "label": "eu-west-2",
+                  "value": "eu-west-2"
+                },
+                {
+                  "label": "eu-west-3",
+                  "value": "eu-west-3"
+                },
+                {
+                  "label": "sa-east-1",
+                  "value": "sa-east-1"
+                },
+                {
+                  "label": "ap-northeast-1",
+                  "value": "ap-northeast-1"
+                },
+                {
+                  "label": "ap-northeast-2",
+                  "value": "ap-northeast-2"
+                },
+                {
+                  "label": "ap-northeast-3",
+                  "value": "ap-northeast-3"
+                },
+                {
+                  "label": "ap-south-1",
+                  "value": "ap-south-1"
+                },
+                {
+                  "label": "ap-southeast-1",
+                  "value": "ap-southeast-1"
+                },
+                {
+                  "label": "ap-southeast-2",
+                  "value": "ap-southeast-2"
+                },
+                {
+                  "label": "ca-central-1",
+                  "value": "ca-central-1"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "name": "stackName",
+              "label": "Enter your stack name",
+              "required": true,
+              "description": "The name of your Cloudwatch stack.",
+              "value": "logzio-cloudwatch-shipper",
+              "pattern": "^[a-zA-Z0-9-]+$",
+              "patternError": "Only letters, numbers and dashes are allowed"
+            }
+          ],
+          "telemetries": [
+            {
+              "type": "LOG_ANALYTICS",
+              "hint": "Switch the toggle on if you want Logz.io Telemetry Collector to collect logs from your Cloudwatch.",
+              "params": [
+                {
+                  "type": "multi-select",
+                  "name": "param_services",
+                  "label": "AWS Services",
+                  "description": "Services that you need to collect logs from.",
+                  "options": [
+                    {
+                      "label": "Amazon Connect",
+                      "value": "connect"
+                    },
+                    {
+                      "label": "Amazon MQ",
+                      "value": "amazon-mq"
+                    },
+                    {
+                      "label": "Amazon Macie",
+                      "value": "macie"
+                    },
+                    {
+                      "label": "API Gateway",
+                      "value": "apigateway"
+                    },
+                    {
+                      "label": "AWS Elastic Beanstalk",
+                      "value": "elasticbeanstalk"
+                    },
+                    {
+                      "label": "AWS Glue",
+                      "value": "aws-glue"
+                    },
+                    {
+                      "label": "AWS IoT",
+                      "value": "aws-iot"
+                    },
+                    {
+                      "label": "CloudHSM",
+                      "value": "cloudhsm"
+                    },
+                    {
+                      "label": "CloudTrail",
+                      "value": "cloudtrail"
+                    },
+                    {
+                      "label": "CodeBuild",
+                      "value": "codebuild"
+                    },
+                    {
+                      "label": "ECS",
+                      "value": "ecs"
+                    },
+                    {
+                      "label": "EKS",
+                      "value": "eks"
+                    },
+                    {
+                      "label": "Lambda",
+                      "value": "lambda"
+                    },
+                    {
+                      "label": "RDS",
+                      "value": "rds"
+                    }
+                  ]
+                },
+                {
+                  "type": "string-list",
+                  "name": "param_customLogGroups",
+                  "label": "Custom Log Groups",
+                  "description": "Custom log groups that you need to collect logs from.",
+                  "placeholder": "Your log group /my/custom/log-group",
+                  "actionText": "Add custom log group"
+                },
+                {
+                  "type": "key-value",
+                  "name": "param_logzioEnrich",
+                  "label": "Fields Enrichment",
+                  "description": "Enrich CloudWatch events with custom fields."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }     
    ]
  }

--- a/configs/3-1-aws-cw.json
+++ b/configs/3-1-aws-cw.json
@@ -123,6 +123,8 @@
       "supportedOs": [
         "AWS_Cloudformation"
       ],
+      "productTags": ["LOG_ANALYTICS"],
+      "filterTags": ["AWS", "Most Popular"],
       "integrationTemplate": "cloudwatch-shipper-trigger/1.1.1/sam-template.yaml&param_logzioType=agent-aws-cloudwatch&param_logzioListener=https://<<LOGZIO_LISTENER_ADDRESS>>:8071",
       "datasources": [
         {

--- a/configs/3-1-aws-cw.json
+++ b/configs/3-1-aws-cw.json
@@ -117,7 +117,7 @@
      {
       "name": "AWS_Cloudwatch_Logs",
       "logo": "https://dytvr9ot2sszz.cloudfront.net/logz-docs/shipper-logos/aws.svg",
-      "label": "AWS Cloudwatch Logs",
+      "label": "Cloudwatch Logs",
       "description": "via Cloudwatch using AWS Lambda",
       "hint": "Cloudwatch logs to ship to Logz.io",
       "supportedOs": [


### PR DESCRIPTION
- Backwards compatibility Cloudwatch logs lambda function shipping method.