### PR TITLE
[Feature] Update aws metrics to use otlp 1.0 lambda consumer

### DIFF
--- a/configs/3-2-aws-metric-stream.json
+++ b/configs/3-2-aws-metric-stream.json
@@ -14,7 +14,7 @@
        "supportedOs": ["AWS_Cloudformation"],
        "productTags": ["METRICS"],
       "filterTags": ["AWS", "Most Popular"],
-       "integrationTemplate": "metric-stream-helpers/aws/1.3.4/sam-template.yaml&param_logzioDestination=https://listener-aws-metrics-stream-<<LOGZIO_ACCOUNT_REGION_CODE>>.logz.io/&param_logzioListener=https://<<LOGZIO_LISTENER_ADDRESS>>:8053",
+       "integrationTemplate": "metric-stream-helpers/aws/1.4.0/sam-template.yaml&param_logzioDestination=https://listener-otlp-aws-metrics-stream-<<LOGZIO_ACCOUNT_REGION_CODE>>.logz.io/&param_logzioListener=https://<<LOGZIO_LISTENER_ADDRESS>>:8053",
        "datasources": [
          {
            "name": "AWS_Metrics",


### PR DESCRIPTION
## Description 

- Update aws metrics to use otlp 1.0 lambda consumer:
  - Update template version
  - Update Parameter value

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
