### PR TITLE
Add version 6.2.6 in the command to prevent breaking

### DIFF
--- a/config-templates/helm.json
+++ b/config-templates/helm.json
@@ -1,6 +1,6 @@
 [
   {
-    "template": "helm install -n monitoring --create-namespace \\"
+    "template": "helm install -n monitoring --create-namespace --version 6.2.6 \\"
   },
   {
     "template": "  --set logs.enabled=true \\",


### PR DESCRIPTION
following upgrade to v7.0.0

## Description 

- Following the release of `logzio-monitoring` version 7.0.0, adding temporarily the last version hardcoded to prevent breaking it in the meantime 

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
