### PR TITLE
Fix otlp receiver naming convention

### DIFF
--- a/resources/otel/receivers/otlp.yaml
+++ b/resources/otel/receivers/otlp.yaml
@@ -16,7 +16,7 @@ windows_run: |
     )
   }
 receiver:
-  otlp:
+  otlp/NAME:
     protocols:
       grpc:
         endpoint: "0.0.0.0:4317"


### PR DESCRIPTION
## Description 
Fixes mismatch between otlp receiver name generated in Opentelemetry configuration and how it's specified in the service pipelines.
<!-- 
    "This PR [adds/removes/fixes/replaces] the [feature/bug/etc].."
    Do not leave this blank.
    If relevant, describe the previous behaviour compared to the behaviour post your code change.
-->

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
